### PR TITLE
Element id

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=7lbb2S9*SC4A
-NEO4J_URI=bolt://localhost:7687
+NEO4J_URI=bolt://neo4j:7687

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=7lbb2S9*SC4A
-NEO4J_URI=bolt://neo4j:7687
+NEO4J_URI=bolt://localhost:7687

--- a/src/main/java/com/solvd/blog/mapper/impl/PostMapper.java
+++ b/src/main/java/com/solvd/blog/mapper/impl/PostMapper.java
@@ -14,7 +14,7 @@ public class PostMapper implements Mapper<Post> {
     public Post toEntity(final Record record) {
         Node node = record.get("post").asNode();
         return new NeoPost(
-                node.get("id").asLong(),
+                node.elementId(),
                 node.get("title").asString(),
                 node.get("content").asString(),
                 node.get("date").asLocalDate()

--- a/src/main/java/com/solvd/blog/mapper/impl/UserMapper.java
+++ b/src/main/java/com/solvd/blog/mapper/impl/UserMapper.java
@@ -16,7 +16,7 @@ public class UserMapper implements Mapper<User> {
     public User toEntity(final Record record) {
         Node node = record.get("user").asNode();
         return new NeoUser(
-                node.get("id").asLong(),
+                node.elementId(),
                 node.get("name").asString(),
                 node.get("email").asString(),
                 new ArrayList<>()

--- a/src/main/java/com/solvd/blog/model/Post.java
+++ b/src/main/java/com/solvd/blog/model/Post.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 
 public interface Post {
 
-    Long id();
+    String id();
 
     String title();
 

--- a/src/main/java/com/solvd/blog/model/User.java
+++ b/src/main/java/com/solvd/blog/model/User.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface User {
 
-    Long id();
+    String id();
 
     String name();
 

--- a/src/main/java/com/solvd/blog/neo4j/NeoPost.java
+++ b/src/main/java/com/solvd/blog/neo4j/NeoPost.java
@@ -11,13 +11,13 @@ import java.time.LocalDate;
 @JsonSerialize(using = PostSerializer.class)
 public final class NeoPost implements Post {
 
-    private final Long id;
+    private final String id;
     private final String title;
     private final String content;
     private final LocalDate date;
 
     @Override
-    public Long id() {
+    public String id() {
         return this.id;
     }
 

--- a/src/main/java/com/solvd/blog/neo4j/NeoUser.java
+++ b/src/main/java/com/solvd/blog/neo4j/NeoUser.java
@@ -12,13 +12,13 @@ import java.util.List;
 @JsonSerialize(using = UserSerializer.class)
 public final class NeoUser implements User {
 
-    private final Long id;
+    private final String id;
     private final String name;
     private final String email;
     private final List<Post> posts;
 
     @Override
-    public Long id() {
+    public String id() {
         return this.id;
     }
 

--- a/src/main/java/com/solvd/blog/request/RqUser.java
+++ b/src/main/java/com/solvd/blog/request/RqUser.java
@@ -9,13 +9,13 @@ import java.util.List;
 @AllArgsConstructor
 public class RqUser implements User {
 
-    private final Long id;
+    private final String id;
     private final String name;
     private final String email;
     private final List<Post> posts;
 
     @Override
-    public Long id() {
+    public String id() {
         return this.id;
     }
 

--- a/src/main/java/com/solvd/blog/serializer/PostSerializer.java
+++ b/src/main/java/com/solvd/blog/serializer/PostSerializer.java
@@ -16,7 +16,7 @@ public class PostSerializer extends JsonSerializer<NeoPost> {
             final SerializerProvider serializers
     ) throws IOException {
         gen.writeStartObject();
-        gen.writeNumberField("id", value.id());
+        gen.writeStringField("id", value.id());
         gen.writeStringField("title", value.title());
         gen.writeStringField("content", value.content());
         gen.writeObjectField("date", value.date());

--- a/src/main/java/com/solvd/blog/serializer/UserSerializer.java
+++ b/src/main/java/com/solvd/blog/serializer/UserSerializer.java
@@ -16,7 +16,7 @@ public class UserSerializer extends JsonSerializer<NeoUser> {
             final SerializerProvider serializers
     ) throws IOException {
         gen.writeStartObject();
-        gen.writeNumberField("id", value.id());
+        gen.writeStringField("id", value.id());
         gen.writeStringField("name", value.name());
         gen.writeStringField("email", value.email());
         gen.writeFieldName("posts");


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the `id` field type from `Long` to `String` in several classes and interfaces, and updates related methods and serializers. 

### Detailed summary
- Changed `id` field type from `Long` to `String` in `User`, `Post`, `NeoUser`, and `NeoPost` interfaces and classes.
- Updated `id()` method return type from `Long` to `String` in `User`, `NeoUser`, and `NeoPost` interfaces and classes, and in `RqUser` class.
- Updated `UserSerializer` and `PostSerializer` to write `id` field as string.
- Removed `asLong()` calls and replaced them with `elementId()` in `UserMapper` and `PostMapper`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->