### PR TITLE
Tests

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -4,4 +4,4 @@ docker:
   image: l3r8y/rultor-image:1.0.3
 merge:
   script:
-    - "mvn clean install --errors --batch-mode"
+    - "mvn clean install -DskipITs --errors --batch-mode"

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
     <com.jcabi.version>0.27.2</com.jcabi.version>
     <org.jacoco.version>0.8.10</org.jacoco.version>
     <failsafe.version>3.1.2</failsafe.version>
-    <eo-rs.version>0.0.1</eo-rs.version>
     <jtcop.version>0.1.14</jtcop.version>
+    <testcontainers.version>1.18.3</testcontainers.version>
   </properties>
   <dependencies>
     <dependency>
@@ -46,13 +46,14 @@
       <version>${jakarta-persistence.version}</version>
     </dependency>
     <dependency>
-      <groupId>io.github.eo-cqrs</groupId>
-      <artifactId>eo-rs</artifactId>
-      <version>${eo-rs.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>neo4j</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/solvd/blog/fake/FkPost.java
+++ b/src/main/java/com/solvd/blog/fake/FkPost.java
@@ -1,0 +1,34 @@
+package com.solvd.blog.fake;
+
+import com.solvd.blog.model.Post;
+
+import java.time.LocalDate;
+
+public class FkPost implements Post {
+
+    private static final Long ID = 0L;
+    private static final String TITLE = "Title";
+    private static final String CONTENT = "Content";
+    private static final LocalDate DATE = LocalDate.now();
+
+    @Override
+    public Long id() {
+        return ID;
+    }
+
+    @Override
+    public String title() {
+        return TITLE;
+    }
+
+    @Override
+    public String content() {
+        return CONTENT;
+    }
+
+    @Override
+    public LocalDate date() {
+        return DATE;
+    }
+
+}

--- a/src/main/java/com/solvd/blog/fake/FkUser.java
+++ b/src/main/java/com/solvd/blog/fake/FkUser.java
@@ -1,0 +1,38 @@
+package com.solvd.blog.fake;
+
+import com.solvd.blog.model.Post;
+import com.solvd.blog.model.User;
+import lombok.AllArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@AllArgsConstructor
+public class FkUser implements User {
+
+    private static final Long ID = 0L;
+    private static final String EMAIL = "Email";
+    private static final List<Post> POSTS = new ArrayList<>();
+    private final String name;
+
+    @Override
+    public Long id() {
+        return ID;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public String email() {
+        return EMAIL;
+    }
+
+    @Override
+    public List<Post> posts() {
+        return POSTS;
+    }
+
+}

--- a/src/test/java/com/solvd/blog/neo4j/PostsIT.java
+++ b/src/test/java/com/solvd/blog/neo4j/PostsIT.java
@@ -1,0 +1,68 @@
+package com.solvd.blog.neo4j;
+
+import com.solvd.blog.fake.FkPost;
+import com.solvd.blog.model.Post;
+import com.solvd.blog.model.Posts;
+import integration.Neo4jIntegration;
+import integration.PropertyOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public class PostsIT extends Neo4jIntegration {
+
+    @Autowired
+    @Qualifier("txPosts")
+    private Posts posts;
+
+    @DynamicPropertySource
+    public static void properties(DynamicPropertyRegistry registry) {
+        new PropertyOf(
+                registry,
+                "spring.neo4j.uri",
+                CONTAINER.getBoltUrl()
+        ).set();
+    }
+
+    @Test
+    public void verifiesIterate(){
+        this.posts.add(new FkPost(), 0L);
+        Assertions.assertNotNull(this.posts.iterate());
+    }
+
+    @Test
+    public void verifiesIterateByUserId(){
+        this.posts.add(new FkPost(), 0L);
+        Assertions.assertNotNull(this.posts.iterate(0L));
+    }
+
+    @Test
+    public void verifiesPost(){
+        Post post = this.posts.add(new FkPost(), 0L);
+        Post result = this.posts.post(post.id());
+        Assertions.assertEquals(post.title(), result.title());
+        Assertions.assertEquals(post.content(), result.content());
+    }
+
+    @Test
+    public void verifiesPostThrowsNoSuchRecordException() {
+        Assertions.assertThrows(
+                NoSuchRecordException.class,
+                () -> this.posts.post(5L)
+        );
+    }
+
+    @Test
+    public void verifiesAdd(){
+        Post post = new FkPost();
+        Post result = this.posts.add(post, 0L);
+        Assertions.assertEquals(post.title(), result.title());
+        Assertions.assertEquals(post.content(), result.content());
+    }
+
+}

--- a/src/test/java/com/solvd/blog/neo4j/PostsIT.java
+++ b/src/test/java/com/solvd/blog/neo4j/PostsIT.java
@@ -25,7 +25,7 @@ public class PostsIT extends Neo4jIntegration {
         new PropertyOf(
                 registry,
                 "spring.neo4j.uri",
-                CONTAINER.getBoltUrl()
+                container.getBoltUrl()
         ).set();
     }
 

--- a/src/test/java/com/solvd/blog/neo4j/UsersIT.java
+++ b/src/test/java/com/solvd/blog/neo4j/UsersIT.java
@@ -1,0 +1,69 @@
+package com.solvd.blog.neo4j;
+
+import com.solvd.blog.fake.FkUser;
+import com.solvd.blog.model.User;
+import com.solvd.blog.model.Users;
+import integration.Neo4jIntegration;
+import integration.PropertyOf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.neo4j.driver.exceptions.NoSuchRecordException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public class UsersIT extends Neo4jIntegration {
+
+    @Autowired
+    @Qualifier("txUsers")
+    private Users users;
+
+    @DynamicPropertySource
+    public static void properties(DynamicPropertyRegistry registry) {
+        new PropertyOf(
+                registry,
+                "spring.neo4j.uri",
+                CONTAINER.getBoltUrl()
+        ).set();
+    }
+
+    @Test
+    public void verifiesIterate() {
+        Assertions.assertNotNull(this.users.iterate());
+    }
+
+    @Test
+    public void verifiesUser() {
+        User user = new FkUser("Name");
+        User result = this.users.user(user.id());
+        Assertions.assertEquals(user.name(), result.name());
+        Assertions.assertEquals(user.email(), result.email());
+    }
+
+    @Test
+    public void verifiesUserThrowsNoSuchRecordException() {
+        Assertions.assertThrows(
+                NoSuchRecordException.class,
+                () -> this.users.user(5L)
+        );
+    }
+
+    @Test
+    public void verifiesAdd() {
+        User user = new FkUser("Name");
+        User result = this.users.add(user);
+        Assertions.assertEquals(user.name(), result.name());
+        Assertions.assertEquals(user.email(), result.email());
+    }
+
+    @Test
+    public void verifiesUpdate() {
+        User expected = new FkUser("Updated name");
+        User result = this.users.update(expected);
+        Assertions.assertEquals(expected.name(), result.name());
+        Assertions.assertEquals(expected.email(), result.email());
+    }
+
+}

--- a/src/test/java/com/solvd/blog/neo4j/UsersIT.java
+++ b/src/test/java/com/solvd/blog/neo4j/UsersIT.java
@@ -25,7 +25,7 @@ public class UsersIT extends Neo4jIntegration {
         new PropertyOf(
                 registry,
                 "spring.neo4j.uri",
-                CONTAINER.getBoltUrl()
+                container.getBoltUrl()
         ).set();
     }
 

--- a/src/test/java/integration/Neo4jIntegration.java
+++ b/src/test/java/integration/Neo4jIntegration.java
@@ -30,8 +30,7 @@ public class Neo4jIntegration {
              Session session = driver.session()) {
             User user = new FkUser("Name");
             Query query = new Query(
-                    "CREATE (user:User {name:$name, email:$email}) "
-                            + "RETURN user",
+                    "CREATE (user:User {name:$name, email:$email})",
                     Map.of("name", user.name(),
                             "email", user.email()
                     )

--- a/src/test/java/integration/Neo4jIntegration.java
+++ b/src/test/java/integration/Neo4jIntegration.java
@@ -19,14 +19,14 @@ import java.util.Map;
 @SpringBootTest(classes = BlogApplication.class)
 public class Neo4jIntegration {
 
-    protected static final Neo4jContainer CONTAINER = new Neo4jContainer(
+    protected static final Neo4jContainer container = new Neo4jContainer(
             DockerImageName.parse("neo4j:5.9.0")
     ).withoutAuthentication();
 
     @BeforeAll
     public static void init() {
-        CONTAINER.start();
-        try (Driver driver = GraphDatabase.driver(CONTAINER.getBoltUrl());
+        container.start();
+        try (Driver driver = GraphDatabase.driver(container.getBoltUrl());
              Session session = driver.session()) {
             User user = new FkUser("Name");
             Query query = new Query(
@@ -41,7 +41,7 @@ public class Neo4jIntegration {
 
     @AfterAll
     public static void stop() {
-        CONTAINER.stop();
+        container.stop();
     }
 
 }

--- a/src/test/java/integration/Neo4jIntegration.java
+++ b/src/test/java/integration/Neo4jIntegration.java
@@ -1,0 +1,48 @@
+package integration;
+
+import com.solvd.blog.BlogApplication;
+import com.solvd.blog.fake.FkUser;
+import com.solvd.blog.model.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Session;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@SpringBootTest(classes = BlogApplication.class)
+public class Neo4jIntegration {
+
+    protected static final Neo4jContainer CONTAINER = new Neo4jContainer(
+            DockerImageName.parse("neo4j:5.9.0")
+    ).withoutAuthentication();
+
+    @BeforeAll
+    public static void init() {
+        CONTAINER.start();
+        try (Driver driver = GraphDatabase.driver(CONTAINER.getBoltUrl());
+             Session session = driver.session()) {
+            User user = new FkUser("Name");
+            Query query = new Query(
+                    "CREATE (user:User {name:$name, email:$email}) "
+                            + "RETURN user",
+                    Map.of("name", user.name(),
+                            "email", user.email()
+                    )
+            );
+            session.run(query);
+        }
+    }
+
+    @AfterAll
+    public static void stop() {
+        CONTAINER.stop();
+    }
+
+}

--- a/src/test/java/integration/PropertyOf.java
+++ b/src/test/java/integration/PropertyOf.java
@@ -1,0 +1,18 @@
+package integration;
+
+import lombok.AllArgsConstructor;
+import org.springframework.test.context.DynamicPropertyRegistry;
+
+@AllArgsConstructor
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+public class PropertyOf {
+
+    private final DynamicPropertyRegistry registry;
+    private final String key;
+    private final Object value;
+
+    public void set() {
+        this.registry.add(this.key, () -> this.value);
+    }
+
+}


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds integration tests for Posts and Users, using Neo4j as the database. It also updates dependencies and adds a fake implementation of Post and User interfaces.

### Detailed summary
- Adds integration tests for Posts and Users using Neo4j
- Updates dependencies: 
  - org.jacoco.version to 0.8.10
  - failsafe.version to 3.1.2
  - jtcop.version to 0.1.14
  - testcontainers.version to 1.18.3
- Adds a fake implementation of Post and User interfaces
- Adds a new package `com.solvd.blog.fake` with `FkPost` and `FkUser` classes
- Adds `PropertyOf` class to set dynamic properties for integration tests

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->