### PR TITLE
Classes renamed

### DIFF
--- a/src/main/java/com/solvd/blog/mapper/impl/PostMapper.java
+++ b/src/main/java/com/solvd/blog/mapper/impl/PostMapper.java
@@ -2,7 +2,7 @@ package com.solvd.blog.mapper.impl;
 
 import com.solvd.blog.mapper.Mapper;
 import com.solvd.blog.model.Post;
-import com.solvd.blog.neo4j.NeoPost;
+import com.solvd.blog.neo4j.NjPost;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.types.Node;
 import org.springframework.stereotype.Component;
@@ -13,7 +13,7 @@ public class PostMapper implements Mapper<Post> {
     @Override
     public Post toEntity(final Record record) {
         Node node = record.get("p").asNode();
-        return new NeoPost(
+        return new NjPost(
                 node.id(),
                 node.get("title").asString(),
                 node.get("content").asString(),

--- a/src/main/java/com/solvd/blog/mapper/impl/UserMapper.java
+++ b/src/main/java/com/solvd/blog/mapper/impl/UserMapper.java
@@ -2,7 +2,7 @@ package com.solvd.blog.mapper.impl;
 
 import com.solvd.blog.mapper.Mapper;
 import com.solvd.blog.model.User;
-import com.solvd.blog.neo4j.NeoUser;
+import com.solvd.blog.neo4j.NjUser;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.types.Node;
 import org.springframework.stereotype.Component;
@@ -15,7 +15,7 @@ public class UserMapper implements Mapper<User> {
     @Override
     public User toEntity(final Record record) {
         Node node = record.get("user").asNode();
-        return new NeoUser(
+        return new NjUser(
                 node.id(),
                 node.get("name").asString(),
                 node.get("email").asString(),

--- a/src/main/java/com/solvd/blog/neo4j/NjPost.java
+++ b/src/main/java/com/solvd/blog/neo4j/NjPost.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 
 @AllArgsConstructor
 @JsonSerialize(using = PostSerializer.class)
-public final class NeoPost implements Post {
+public final class NjPost implements Post {
 
     private final Long id;
     private final String title;

--- a/src/main/java/com/solvd/blog/neo4j/NjPosts.java
+++ b/src/main/java/com/solvd/blog/neo4j/NjPosts.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 @Component
 @RequiredArgsConstructor
-public class NeoPosts implements Posts {
+public class NjPosts implements Posts {
 
     private final Driver driver;
     private final PostMapper mapper;

--- a/src/main/java/com/solvd/blog/neo4j/NjUser.java
+++ b/src/main/java/com/solvd/blog/neo4j/NjUser.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @AllArgsConstructor
 @JsonSerialize(using = UserSerializer.class)
-public final class NeoUser implements User {
+public final class NjUser implements User {
 
     private final Long id;
     private final String name;

--- a/src/main/java/com/solvd/blog/neo4j/NjUsers.java
+++ b/src/main/java/com/solvd/blog/neo4j/NjUsers.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class NeoUsers implements Users {
+public class NjUsers implements Users {
 
     private final Driver driver;
     private final UserMapper userMapper;

--- a/src/main/java/com/solvd/blog/serializer/PostSerializer.java
+++ b/src/main/java/com/solvd/blog/serializer/PostSerializer.java
@@ -3,15 +3,15 @@ package com.solvd.blog.serializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.solvd.blog.neo4j.NeoPost;
+import com.solvd.blog.neo4j.NjPost;
 
 import java.io.IOException;
 
-public class PostSerializer extends JsonSerializer<NeoPost> {
+public class PostSerializer extends JsonSerializer<NjPost> {
 
     @Override
     public void serialize(
-            final NeoPost value,
+            final NjPost value,
             final JsonGenerator gen,
             final SerializerProvider serializers
     ) throws IOException {

--- a/src/main/java/com/solvd/blog/serializer/UserSerializer.java
+++ b/src/main/java/com/solvd/blog/serializer/UserSerializer.java
@@ -3,15 +3,15 @@ package com.solvd.blog.serializer;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.solvd.blog.neo4j.NeoUser;
+import com.solvd.blog.neo4j.NjUser;
 
 import java.io.IOException;
 
-public class UserSerializer extends JsonSerializer<NeoUser> {
+public class UserSerializer extends JsonSerializer<NjUser> {
 
     @Override
     public void serialize(
-            final NeoUser value,
+            final NjUser value,
             final JsonGenerator gen,
             final SerializerProvider serializers
     ) throws IOException {

--- a/src/main/java/com/solvd/blog/transaction/TxPosts.java
+++ b/src/main/java/com/solvd/blog/transaction/TxPosts.java
@@ -1,4 +1,4 @@
-package com.solvd.blog.tx;
+package com.solvd.blog.transaction;
 
 import com.solvd.blog.model.Post;
 import com.solvd.blog.model.Posts;
@@ -22,7 +22,7 @@ public class TxPosts implements Posts {
      *
      * @param posts Posts
      */
-    public TxPosts(@Qualifier("neoPosts") final Posts posts) {
+    public TxPosts(@Qualifier("njPosts") final Posts posts) {
         this.posts = posts;
     }
 

--- a/src/main/java/com/solvd/blog/transaction/TxUsers.java
+++ b/src/main/java/com/solvd/blog/transaction/TxUsers.java
@@ -1,15 +1,15 @@
-package com.solvd.blog.unique;
+package com.solvd.blog.transaction;
 
-import com.solvd.blog.exception.ResourceAlreadyExistsException;
 import com.solvd.blog.model.User;
 import com.solvd.blog.model.Users;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Component
-public class UqUsers implements Users {
+public class TxUsers implements Users {
 
     private final Users users;
 
@@ -18,36 +18,36 @@ public class UqUsers implements Users {
      *
      * @param users Users
      */
-    public UqUsers(@Qualifier("txUsers") final Users users) {
+    public TxUsers(@Qualifier("njUsers") final Users users) {
         this.users = users;
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<User> iterate() {
         return this.users.iterate();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public User user(final Long id) {
         return this.users.user(id);
     }
 
     @Override
+    @Transactional
     public User add(final User user) {
-        if (this.exists(user.email())) {
-            throw new ResourceAlreadyExistsException(
-                    "Email should be unique!"
-            );
-        }
         return this.users.add(user);
     }
 
     @Override
+    @Transactional
     public User update(final User user) {
         return this.users.update(user);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Boolean exists(final String email) {
         return this.users.exists(email);
     }

--- a/src/main/java/com/solvd/blog/validation/VdUsers.java
+++ b/src/main/java/com/solvd/blog/validation/VdUsers.java
@@ -1,15 +1,15 @@
-package com.solvd.blog.tx;
+package com.solvd.blog.validation;
 
+import com.solvd.blog.exception.ResourceAlreadyExistsException;
 import com.solvd.blog.model.User;
 import com.solvd.blog.model.Users;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Component
-public class TxUsers implements Users {
+public class VdUsers implements Users {
 
     private final Users users;
 
@@ -18,36 +18,36 @@ public class TxUsers implements Users {
      *
      * @param users Users
      */
-    public TxUsers(@Qualifier("neoUsers") final Users users) {
+    public VdUsers(@Qualifier("txUsers") final Users users) {
         this.users = users;
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<User> iterate() {
         return this.users.iterate();
     }
 
     @Override
-    @Transactional(readOnly = true)
     public User user(final Long id) {
         return this.users.user(id);
     }
 
     @Override
-    @Transactional
     public User add(final User user) {
+        if (this.exists(user.email())) {
+            throw new ResourceAlreadyExistsException(
+                    "Email should be unique!"
+            );
+        }
         return this.users.add(user);
     }
 
     @Override
-    @Transactional
     public User update(final User user) {
         return this.users.update(user);
     }
 
     @Override
-    @Transactional(readOnly = true)
     public Boolean exists(final String email) {
         return this.users.exists(email);
     }

--- a/src/main/java/com/solvd/blog/web/UserController.java
+++ b/src/main/java/com/solvd/blog/web/UserController.java
@@ -36,7 +36,7 @@ public final class UserController {
      * @param posts TxPosts
      */
     public UserController(
-            @Qualifier("uqUsers") final Users users,
+            @Qualifier("vdUsers") final Users users,
             @Qualifier("txPosts") final Posts posts
     ) {
         this.users = users;

--- a/src/test/java/com/solvd/blog/neo4j/UsersIT.java
+++ b/src/test/java/com/solvd/blog/neo4j/UsersIT.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.DynamicPropertySource;
 public class UsersIT extends Neo4jIntegration {
 
     @Autowired
-    @Qualifier("uqUsers")
+    @Qualifier("vdUsers")
     private Users users;
 
     @DynamicPropertySource


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR replaces the `Neo` prefix with `Nj` in Neo4j-related classes, renames `UqUsers` to `VdUsers`, and updates the `UserController` and `TxPosts` and `TxUsers` constructor parameters accordingly.

### Detailed summary
- Replaced `Neo` prefix with `Nj` in `NjPosts`, `NjUsers`, `NjPost`, and `NjUser` classes
- Renamed `UqUsers` to `VdUsers`
- Updated `UserController` constructor parameter to use `VdUsers` instead of `UqUsers`
- Updated `TxPosts` constructor parameter to use `NjPosts` instead of `NeoPosts`
- Updated `TxUsers` constructor parameter to use `NjUsers` instead of `NeoUsers`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->